### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A powerful context management system designed specifically for software development teams. The Developer MCP Server maintains persistent context across your coding sessions, ensuring you never lose track of your project's structure, dependencies, and progress.
 
+<a href="https://glama.ai/mcp/servers/@tejpalvirk/developer">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tejpalvirk/developer/badge" alt="Developer Server MCP server" />
+</a>
+
 ## Features
 
 - **Persistent Development Context**: Pick up exactly where you left off in your last session, with complete context about the components, issues, and tasks you were working on.
@@ -264,4 +268,4 @@ docker build -t mcp/developer -f developer/Dockerfile .
 
 ## License
 
-This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository. 
+This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.


### PR DESCRIPTION
This PR adds a badge for the [Developer MCP Server](https://glama.ai/mcp/servers/@tejpalvirk/developer) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tejpalvirk/developer">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tejpalvirk/developer/badge" alt="Developer Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.